### PR TITLE
Fix: add missing quote in error message

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,7 +31,7 @@ final class Factory
     {
         if (\PHP_VERSION_ID < $ruleSet->targetPhpVersion()) {
             throw new \RuntimeException(\sprintf(
-                'Current PHP version "%s is less than targeted PHP version "%s".',
+                'Current PHP version "%s" is less than targeted PHP version "%s".',
                 \PHP_VERSION_ID,
                 $ruleSet->targetPhpVersion()
             ));

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -52,7 +52,7 @@ final class FactoryTest extends Framework\TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf(
-            'Current PHP version "%s is less than targeted PHP version "%s".',
+            'Current PHP version "%s" is less than targeted PHP version "%s".',
             \PHP_VERSION_ID,
             $targetPhpVersion
         ));


### PR DESCRIPTION
This PR

* [x] Adds a missing closing quote in the error message when the minimum required PHP version is not satisfied.

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/21.
