### PR TITLE
Fix: Disable all rules other than PSR2

### DIFF
--- a/src/RuleSet/Custom.php
+++ b/src/RuleSet/Custom.php
@@ -151,9 +151,7 @@ final class Custom extends AbstractRuleSet
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,
-        'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'self',
-        ],
+        'php_unit_test_case_static_method_calls' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => false,
         'phpdoc_align' => false,

--- a/test/Unit/RuleSet/CustomTest.php
+++ b/test/Unit/RuleSet/CustomTest.php
@@ -157,9 +157,7 @@ final class CustomTest extends AbstractRuleSetTestCase
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,
-        'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'self',
-        ],
+        'php_unit_test_case_static_method_calls' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => false,
         'phpdoc_align' => false,


### PR DESCRIPTION
This PR

* [x] disables all rules other than `@PSR2`