### PR TITLE
Fix: Rename method

### DIFF
--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -63,7 +63,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         ));
     }
 
-    final public function testRuleSetDoesDoNotConfigureRulesThatAreNotBuiltIn(): void
+    final public function testRuleSetDoesNotConfigureRulesThatAreNotBuiltIn(): void
     {
         $namesOfRulesThatAreConfiguredAndNotBuiltIn = \array_diff(
             self::namesOfRulesThatAreConfigured(),


### PR DESCRIPTION
This PR

* [x] renames a method