### PR TITLE
Fix: Remove unused import

### DIFF
--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
 use Ergebnis\PhpCsFixer\Config;
-use Ergebnis\PhpCsFixer\Config\Test\Fixture;
 use Ergebnis\Test\Util;
 use PHPUnit\Framework;
 


### PR DESCRIPTION
This PR

* [x] removes an unused import